### PR TITLE
fix and improve stdio error handling

### DIFF
--- a/dictpw.c
+++ b/dictpw.c
@@ -34,8 +34,6 @@ static int nflag = 5; /* How many words make up a password. */
 static int hflag = 0; /* Has the help flag been used? */
 
 static void usage(void);
-static void fputs_noerr(const char *, FILE *);
-static void fputc_noerr(int, FILE *);
 
 int
 main(int argc, char *argv[])
@@ -84,17 +82,16 @@ main(int argc, char *argv[])
 		exit(0);
 	}
 
-	/*
-	 * We can afford some pedantic code, but we can't afford a bad password,
-	 * so error check the printing functions.
-	 */
 	for (i = 0; i++ < nflag;) {
-		fputs_noerr(dict[arc4random_uniform(dictlen)], stdout);
+		fputs(dict[arc4random_uniform(dictlen)], stdout);
 		if (i < nflag)
-			fputc_noerr('.', stdout);
+			fputc('.', stdout);
 		else
-			fputc_noerr('\n', stdout);
+			fputc('\n', stdout);
 	}
+	fflush(stdout);
+	if (ferror(stdout))
+		errx(1, "Failed to write to stdout");
 	exit(0);
 }
 
@@ -104,20 +101,4 @@ usage(void)
 	fprintf(stderr, "usage:"
 	    "\t%s [-h] [-n %d <= words <= %d]\n", getprogname(), MINWORD,
 	    MAXWORD);
-}
-
-static void
-fputs_noerr(const char *str, FILE *stream)
-{
-	errno = 0;
-	if (fputs(str, stream) == EOF && errno != 0)
-		err(1, "fputs");
-}
-
-static void
-fputc_noerr(int c, FILE *stream)
-{
-	errno = 0;
-	if (putc(c, stream) == EOF && errno != 0)
-		err(1, "putc");
 }


### PR DESCRIPTION
the IO error checking currently done via the `*_noerr` functions are entirely misguided. stdio functions are typically buffered, so most of these calls are more or less just memcpy. and since the password isn't likely going to be big enough to fill the buffer to cause a flush (i,e an *actual* IO operation) these calls are almost never going to fail - with the exception of the newline character - which might cause a flush if stdout is "interactive" and thus set to line-buffered mode.

but there's no guarantee stdout is interactive, user might want to pipe the output to some encryption tool for example. in such cases, the stdout flush will occur due to calling `exit()` and any errors that occur at that point will be entirely missed by the application.

the proper way to error check stdio functions is to manually flush at the end and check for the error flag on the stream. here's the result before and after the patch:

	[dictpw master]~> ./build/dictpw >/dev/full
	[dictpw io_err]~> ./build/dictpw >/dev/full
	dictpw: Failed to write to stdout

additionally, the way `*_noerr` functions are checking for `errno` is also confusing:

* if the plan is to support only POSIX systems, then POSIX specifies fputs and fputc to set the errno on failure. so the `errno != 0` check is entirely redundant.
* and if non-POSIX systems are to be supported, then the check is *incorrect* since ISO C doesn't require errno to be set for these functions on failure. so if such a system exists, the application will see that fputs failed but errno is 0 and thus will march on thinking everything went fine.

one regression from this patch is that the exact cause of error is not known anymore. so the error message will be the same for any errors.